### PR TITLE
Convert Dockerfile to multi-stage build with non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,30 @@
-FROM golang:1.26-alpine
+FROM golang:1.26-alpine AS builder
 
 ENV GOPROXY="https://proxy.golang.org"
-ENV GO111MODULE="on"
+ENV CGO_ENABLED=0
+
+WORKDIR /app
+
+# Cache dependency downloads separately from source changes.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -ldflags="-s -w" -o /server .
+
+# ── Runtime image ─────────────────────────────────────────────────────────────
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata
+
 ENV NAT_ENV="production"
 
 EXPOSE 8080
 
-WORKDIR /go/src/github.com/icco/hello
+# Run as a non-root user.
+RUN adduser -S -u 1001 app
+USER app
 
-RUN apk add --no-cache git
-COPY . .
+COPY --from=builder /server /server
 
-RUN go build -v -o /go/bin/server .
-
-CMD ["/go/bin/server"]
+CMD ["/server"]


### PR DESCRIPTION
## Problem

The `Dockerfile` used a single-stage build:

```dockerfile
FROM golang:1.26-alpine
RUN apk add --no-cache git
COPY . .
RUN go build -v -o /go/bin/server .
CMD ["/go/bin/server"]
```

The final container image included the full Go compiler toolchain, `git`, and all build utilities — greatly increasing the attack surface. The process also ran as **root** (no `USER` instruction).

## Fix

- Split into **builder** (`golang:1.26-alpine`) and minimal **runtime** (`alpine:3.21`) stages
- Added `go mod download` in a separate layer for build-cache efficiency
- Stripped debug symbols with `-ldflags="-s -w"`
- Added `ca-certificates` and `tzdata` to the runtime image
- Added a non-root system user (uid 1001)

## Testing

```bash
docker build -t hello .
docker run --rm -e PORT=8080 -p 8080:8080 hello
docker run --rm hello id   # should show uid=1001(app)
docker images hello        # image size should be ~15–20 MB vs ~300 MB before
```

## Audit notes

| Area | Finding | Action |
|------|---------|--------|
| Dockerfile | Single-stage build, runs as root | **Fixed (this PR)** |
| `go.mod` | Go 1.25, minimal dependencies — all current | No action needed |
| Source code | Simple HTTP server, no auth, serves static content | No action needed |
