### PR TITLE
Upgrade runtime base image from alpine:3.21 to alpine:3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN go build -ldflags="-s -w" -o /server .
 
 # ── Runtime image ─────────────────────────────────────────────────────────────
-FROM alpine:3.21
+FROM alpine:3.22
 
 RUN apk add --no-cache ca-certificates tzdata
 


### PR DESCRIPTION
## Problem

The final runtime stage used `alpine:3.21`, which was released in November 2024 and has since been superseded by `alpine:3.22` (May 2025). Alpine 3.21 is missing security patches that 3.22 includes.

## Fix

```diff
-FROM alpine:3.21
+FROM alpine:3.22
```

Single-line bump; no other changes. The non-root user (`app`, UID 1001) and all other best practices were already in place.

## Testing

```bash
docker build -t hello-test .
docker run --rm hello-test id
# uid=1001(app) gid=65533(nogroup) ...
```

## Audit Note

**Reviewed**: Dockerfile, go.mod, main.go  
**Found & fixed**: outdated alpine:3.21 base image  
**Already good**: runs as non-root, uses multi-stage build, CGO disabled, `-s -w` ldflags  
**Skipped / future run**: go.mod is on `go 1.25`; dependencies appear current (chi v5.2.5, gutil recent)
