### PR TITLE
Fix missing HTTP server timeouts (slow-loris DoS prevention)

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	chi "github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -46,7 +47,15 @@ func main() {
 	r.Get("/healthz", hello("json"))
 	r.HandleFunc("/204", twoOhFour)
 
-	log.Fatal(http.ListenAndServe(":"+port, r))
+	srv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	log.Fatal(srv.ListenAndServe())
 }
 
 type helloRespJSON struct {


### PR DESCRIPTION
## Problem

`main.go` starts the HTTP server with bare `http.ListenAndServe`:

```go
// BEFORE
log.Fatal(http.ListenAndServe(":"+port, r))
```

`http.ListenAndServe` creates a server with **zero timeouts**: no `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout`, or `IdleTimeout`. A slow client that trickles headers (slow-loris attack) will hold a goroutine and file descriptor open indefinitely. Under enough such connections the server exhausts available file descriptors and becomes unavailable to legitimate clients.

## Fix

Replace with an explicit `http.Server` that configures all four timeouts:

```go
// AFTER
srv := &http.Server{
    Addr:              ":" + port,
    Handler:           r,
    ReadHeaderTimeout: 5 * time.Second,
    ReadTimeout:       10 * time.Second,
    WriteTimeout:      10 * time.Second,
    IdleTimeout:       60 * time.Second,
}
log.Fatal(srv.ListenAndServe())
```

## Testing steps

1. `go build ./...` — should compile cleanly.
2. `go test ./...` — existing tests (if any) should pass.
3. Start the service and verify it responds normally.

## Audit note

**Reviewed:** `main.go`, `go.mod`, `Dockerfile`.

**Other findings (not fixed here):**
- `hello` has no tests. A simple smoke test for the `/healthz` and `/json` endpoints would be low-effort and high-value.
- The existing `audit/multistage-dockerfile` and `audit/upgrade-alpine-3.22` branches have no open PRs.
- Dependencies look current (`go 1.25.0`).

**No existing open `audit/` PR targeting this area before this one.**
