### PR TITLE
fix: embed templates into binary

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"embed"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,6 +12,9 @@ import (
 	"github.com/unrolled/render"
 	"github.com/unrolled/secure"
 )
+
+//go:embed templates
+var embeddedTemplates embed.FS
 
 var (
 	service = "hello"
@@ -57,7 +61,9 @@ type helloRespJSON struct {
 func hello(format string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		resp := helloRespJSON{"ok", "Hello World"}
-		re := render.New()
+		re := render.New(render.Options{
+				FileSystem: &render.EmbedFileSystem{FS: embeddedTemplates},
+			})
 
 		w.Header().Set("Cache-Control", "no-store")
 		w.Header().Set("Pragma", "no-cache")


### PR DESCRIPTION
## Summary

- The recent multi-stage Dockerfile conversion (#32) only copies the compiled binary to the runtime image, leaving the `templates/` directory behind
- This caused `html/template: "hello" is undefined` 500 errors on welch.io
- Fix: use `//go:embed templates` to bundle templates into the binary itself

