### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN go build -ldflags="-s -w" -o /server .
 # ── Runtime image ─────────────────────────────────────────────────────────────
 FROM alpine:3.23
 
+LABEL org.opencontainers.image.source=https://github.com/icco/hello
+LABEL org.opencontainers.image.description="A simple hello"
+LABEL org.opencontainers.image.licenses=MIT
+
 RUN apk add --no-cache ca-certificates tzdata
 
 ENV NAT_ENV="production"


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)